### PR TITLE
Trim account names and enforce length validation

### DIFF
--- a/tests/test_account_name_validation.py
+++ b/tests/test_account_name_validation.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+os.environ['DATABASE_URL'] = 'sqlite:///test.db'
+
+from app import create_app, db
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config.update(TESTING=True)
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    if os.path.exists('test.db'):
+        os.remove('test.db')
+
+def register(client):
+    client.post('/auth/register', data={'email': 'test@example.com', 'password': 'pass'}, follow_redirects=True)
+
+def test_account_name_validation(client):
+    register(client)
+    res = client.post('/api/accounts', json={'name': '   ', 'type': 'cash'})
+    assert res.status_code == 400
+    assert res.get_json()['errors']['name'] == ['required or length']
+    res = client.post('/api/accounts', json={'name': 'x' * 81, 'type': 'cash'})
+    assert res.status_code == 400
+    assert res.get_json()['errors']['name'] == ['required or length']
+    res = client.post('/api/accounts', json={'name': '  Cash  ', 'type': 'cash'})
+    assert res.status_code == 201
+    assert res.get_json()['data']['name'] == 'Cash'
+    acc_id = res.get_json()['data']['id']
+    res = client.post('/api/accounts', json={'name': 'Cash ', 'type': 'cash'})
+    assert res.status_code == 409
+    res = client.post('/api/accounts', json={'name': 'Wallet', 'type': 'cash'})
+    assert res.status_code == 201
+    acc2_id = res.get_json()['data']['id']
+    res = client.put(f'/api/accounts/{acc2_id}', json={'name': '  Cash  '})
+    assert res.status_code == 409
+    res = client.put(f'/api/accounts/{acc_id}', json={'name': '   '})
+    assert res.status_code == 400
+    res = client.put(f'/api/accounts/{acc_id}', json={'name': 'x' * 81})
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- Strip whitespace from account names on create/update and ensure duplicates use trimmed names
- Validate account names must be 1-80 characters long and return detailed errors
- Add tests covering name trimming, length validation, and duplicate detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee51fb84832dac365727f919535d