### PR TITLE
Validate category names

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -335,13 +335,15 @@ def categories_list():
 @login_required
 def categories_create():
     data = request.get_json() or {}
-    name = data.get("name")
+    name = (data.get("name") or "").strip()
     kind = data.get("kind")
     color = data.get("color", "#888888")
     icon_emoji = data.get("icon_emoji")
     parent_id = data.get("parent_id")
     is_system = data.get("is_system", False)
-    if not name or not kind:
+    if not name or not (1 <= len(name) <= 60):
+        return _error("invalid name", errors={"name": ["required or length"]})
+    if not kind:
         return _error("name and kind required")
     supports_partial = _supports_partial_index()
     if not supports_partial:
@@ -391,7 +393,9 @@ def categories_update(id):
     c = _get_category(id)
     data = request.get_json() or {}
     if "name" in data:
-        name = data["name"]
+        name = (data["name"] or "").strip()
+        if not name or not (1 <= len(name) <= 60):
+            return _error("invalid name", errors={"name": ["required or length"]})
         supports_partial = _supports_partial_index()
         if not supports_partial:
             exists = (
@@ -403,6 +407,7 @@ def categories_update(id):
             )
             if exists:
                 return _error("duplicate category name", status=409, errors={"name": ["exists"]})
+        data["name"] = name
     for field in ["name", "kind", "color", "icon_emoji", "parent_id", "is_system"]:
         if field in data:
             setattr(c, field, data[field])

--- a/tests/test_category_name_validation.py
+++ b/tests/test_category_name_validation.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+os.environ['DATABASE_URL'] = 'sqlite:///test.db'
+
+from app import create_app, db
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config.update(TESTING=True)
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    if os.path.exists('test.db'):
+        os.remove('test.db')
+
+def register(client):
+    client.post('/auth/register', data={'email': 'test@example.com', 'password': 'pass'}, follow_redirects=True)
+
+
+def test_category_name_validation(client):
+    register(client)
+    res = client.post('/api/categories', json={'name': '   ', 'kind': 'expense'})
+    assert res.status_code == 400
+    assert res.get_json()['errors']['name'] == ['required or length']
+    res = client.post('/api/categories', json={'name': 'x' * 61, 'kind': 'expense'})
+    assert res.status_code == 400
+    assert res.get_json()['errors']['name'] == ['required or length']
+    res = client.post('/api/categories', json={'name': '  Food  ', 'kind': 'expense'})
+    assert res.status_code == 201
+    assert res.get_json()['data']['name'] == 'Food'
+    cat_id = res.get_json()['data']['id']
+    res = client.post('/api/categories', json={'name': 'fOoD ', 'kind': 'expense'})
+    assert res.status_code == 409
+    res = client.post('/api/categories', json={'name': 'Groceries', 'kind': 'expense'})
+    assert res.status_code == 201
+    cat2_id = res.get_json()['data']['id']
+    res = client.put(f'/api/categories/{cat2_id}', json={'name': '  FoOd  '})
+    assert res.status_code == 409
+    res = client.put(f'/api/categories/{cat_id}', json={'name': '   '})
+    assert res.status_code == 400
+    res = client.put(f'/api/categories/{cat_id}', json={'name': 'x' * 61})
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- Trim category names and enforce 1-60 char length
- Ensure case-insensitive uniqueness for active categories on create/update
- Add tests for category name validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d60c1d8c832db5c66403e1aa0b19