### PR TITLE
Validate and normalize category colors

### DIFF
--- a/tests/test_category_color_validation.py
+++ b/tests/test_category_color_validation.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+os.environ['DATABASE_URL'] = 'sqlite:///test.db'
+
+from app import create_app, db
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config.update(TESTING=True)
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    if os.path.exists('test.db'):
+        os.remove('test.db')
+
+def register(client):
+    client.post('/auth/register', data={'email': 'test@example.com', 'password': 'pass'}, follow_redirects=True)
+
+
+def test_category_color_validation(client):
+    register(client)
+    # Invalid color on create
+    res = client.post('/api/categories', json={'name': 'Bad', 'kind': 'expense', 'color': '#123'})
+    assert res.status_code == 422
+    assert res.get_json()['errors']['color'] == ['invalid hex']
+
+    # Valid color without # and lowercase
+    res = client.post('/api/categories', json={'name': 'Food', 'kind': 'expense', 'color': 'ff00ff'})
+    assert res.status_code == 201
+    cat = res.get_json()['data']
+    assert cat['color'] == '#FF00FF'
+    cat_id = cat['id']
+
+    # Update with mixed-case and leading #
+    res = client.put(f'/api/categories/{cat_id}', json={'color': '#00ff00'})
+    assert res.status_code == 200
+    assert res.get_json()['data']['color'] == '#00FF00'
+
+    # Invalid color on update
+    res = client.put(f'/api/categories/{cat_id}', json={'color': 'xyz'})
+    assert res.status_code == 422
+    assert res.get_json()['errors']['color'] == ['invalid hex']

--- a/tests/test_crud_api.py
+++ b/tests/test_crud_api.py
@@ -58,7 +58,7 @@ def test_cruds(client):
     res = client.get('/api/categories')
     assert len(res.get_json()['data']) == 1
     res = client.put(f'/api/categories/{cat_id}', json={'color': '#ff0000'})
-    assert res.get_json()['data']['color'] == '#ff0000'
+    assert res.get_json()['data']['color'] == '#FF0000'
     res = client.delete(f'/api/categories/{cat_id}')
     assert res.get_json()['success'] is True
     assert client.get('/api/categories').get_json()['data'] == []


### PR DESCRIPTION
## Summary
- Enforce strict hex color format for categories
- Normalize accepted colors to `#RRGGBB`
- Add tests covering color normalization and invalid input handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d74b03fc832d9a6b410a9302b0ad