### PR TITLE
Validate category emoji input

### DIFF
--- a/tests/test_crud_api.py
+++ b/tests/test_crud_api.py
@@ -89,6 +89,17 @@ def test_cruds(client):
     assert updated['icon_emoji'] == '\u26A1'
     assert updated['is_system'] is True
 
+    res = client.post(
+        '/api/categories',
+        json={'name': 'Bad', 'kind': 'expense', 'icon_emoji': 'abc'},
+    )
+    assert res.status_code == 422
+    res = client.put(
+        f'/api/categories/{child_id}',
+        json={'icon_emoji': '👨‍👩‍👦'},
+    )
+    assert res.status_code == 422
+
     # Rules
     res = client.post('/api/rules', json={'pattern': 'Star', 'category_id': cat_id})
     assert res.status_code == 201


### PR DESCRIPTION
## Summary
- Add Unicode normalization and regex validation for category `icon_emoji`
- Reject invalid emoji on create/update and allow clearing the field
- Test emoji validation, including invalid inputs

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d8c2329c832d879f687ab2c0cff4