### PR TITLE
Add safeguards for system categories and soft-delete confirmations

### DIFF
--- a/migrations/versions/20240503_unique_active_name_indexes.py
+++ b/migrations/versions/20240503_unique_active_name_indexes.py
@@ -24,8 +24,8 @@ def upgrade():
         'category',
         [sa.text('lower(name)'), 'user_id'],
         unique=True,
-        sqlite_where=sa.text('deleted_at IS NULL'),
-        postgresql_where=sa.text('deleted_at IS NULL'),
+        sqlite_where=sa.text('deleted_at IS NULL AND is_system = 0'),
+        postgresql_where=sa.text('deleted_at IS NULL AND is_system = FALSE'),
     )
 
 

--- a/tests/test_no_active_duplicates.py
+++ b/tests/test_no_active_duplicates.py
@@ -45,8 +45,15 @@ def test_no_duplicate_active_categories(client):
     cat_id = res.get_json()['data']['id']
     res = client.post('/api/categories', json={'name': 'Food', 'kind': 'expense'})
     assert res.status_code == 409
-    client.delete(f'/api/categories/{cat_id}')
+    client.delete(f'/api/categories/{cat_id}?confirm=true')
     res = client.post('/api/categories', json={'name': 'Food', 'kind': 'expense'})
     assert res.status_code == 201
     res_restore = client.post(f'/api/categories/{cat_id}/restore')
     assert res_restore.status_code == 409
+
+    res_sys = client.post('/api/categories', json={'name': 'Sys', 'kind': 'expense', 'is_system': True})
+    assert res_sys.status_code == 201
+    res_user = client.post('/api/categories', json={'name': 'Sys', 'kind': 'expense'})
+    assert res_user.status_code == 201
+    res_user_dup = client.post('/api/categories', json={'name': 'Sys', 'kind': 'expense'})
+    assert res_user_dup.status_code == 409


### PR DESCRIPTION
## Summary
- prevent `is_system` field from being modified and require explicit confirmation before deleting categories
- ignore system categories when checking for duplicate names and update unique index accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61f676a54832da9a6663535b2f029