### PR TITLE
Add container orchestration and CI for image builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,22 @@
-# Flask / App
-SECRET_KEY=change-me-in-prod
-FLASK_ENV=development
+# Database configuration
+DB_HOST=db
+DB_PORT=5432
+DB_NAME=fintrack
+DB_USER=fintrack_user
+DB_PASSWORD=change_me
 
-# Database
-# Use SQLite by default; switch to MySQL or Postgres later
-DATABASE_URL=sqlite:///fintrack.db
+# Redis configuration
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=
 
-# Uploads
-UPLOAD_FOLDER=app/uploads
-MAX_UPLOAD_MB=10
-ALLOWED_EXTENSIONS=jpg,jpeg,png,pdf
+# Discord bot configuration
+DISCORD_TOKEN=
+DISCORD_GUILD_ID=
+
+# Notion configuration
+NOTION_API_KEY=
+NOTION_DATABASE_ID=
+
+# HMAC secret
+HMAC_SECRET=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build and Push Images
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push api
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: services/api/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/api:latest
+      - name: Build and push bot
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: services/bot/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/bot:latest
+      - name: Build and push worker
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: services/worker/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/worker:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+dev:
+	docker-compose up --build
+
+build:
+	docker-compose build
+
+up:
+	docker-compose up -d
+
+logs:
+	docker-compose logs -f
+
+migrate:
+	docker-compose run --rm api alembic upgrade head

--- a/cloudflared/config.yaml.example
+++ b/cloudflared/config.yaml.example
@@ -1,0 +1,13 @@
+tunnel: your-tunnel-id
+credentials-file: /etc/cloudflared/your-tunnel-id.json
+
+ingress:
+  - hostname: api.example.com
+    service: http://api:8000
+  - hostname: bot.example.com
+    service: http://bot:3000
+  - hostname: worker.example.com
+    service: http://worker:3000
+  - hostname: n8n.example.com
+    service: http://n8n:5678
+  - service: http_status:404

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+services:
+  api:
+    build:
+      context: .
+      dockerfile: services/api/Dockerfile
+    env_file: .env
+    depends_on:
+      - db
+      - redis
+  bot:
+    build:
+      context: .
+      dockerfile: services/bot/Dockerfile
+    env_file: .env
+    depends_on:
+      - api
+  worker:
+    build:
+      context: .
+      dockerfile: services/worker/Dockerfile
+    env_file: .env
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  n8n:
+    image: n8nio/n8n
+    ports:
+      - "5678:5678"
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  db-data:

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "run.py"]

--- a/services/bot/Dockerfile
+++ b/services/bot/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "bot.py"]

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "worker.py"]


### PR DESCRIPTION
## Summary
- add docker-compose setup for api, bot, worker, db, redis, n8n and watchtower
- provide Dockerfiles for api, bot and worker
- include Makefile, env template, cloudflared config and GH Actions workflow for image builds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac807ad0e0832db27e9b5d00cb7742