### PR TITLE
feat: add FastAPI service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ pytest==8.2.0
 itsdangerous==2.2.0
 passlib[bcrypt]==1.7.4
 reportlab==4.2.2
+fastapi==0.111.0
+uvicorn==0.29.0
+SQLAlchemy==2.0.30
+pydantic==2.7.1

--- a/services/api/app/__init__.py
+++ b/services/api/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/services/api/app/classify.py
+++ b/services/api/app/classify.py
@@ -1,0 +1,24 @@
+import re
+
+def apply_rules(rules, tx_dict):
+    """Apply simple rules to a transaction dict.
+    rules: iterable of dicts: {pattern, field, min_amount, max_amount, category_id, active, priority}
+    tx_dict: {merchant, note, amount}
+    """
+    candidates = sorted([r for r in rules if r.get("active", True)], key=lambda r: r.get("priority", 100))
+    for r in candidates:
+        field_val = (tx_dict.get("note") if r.get("field") == "note" else tx_dict.get("merchant")) or ""
+        ok = False
+        pat = r.get("pattern","")
+        if pat.startswith("re:"):
+            ok = re.search(pat[3:], field_val, re.I) is not None
+        else:
+            ok = pat.lower() in field_val.lower()
+
+        amt = float(tx_dict.get("amount", 0))
+        if r.get("min_amount") is not None and amt < float(r["min_amount"]): ok = False
+        if r.get("max_amount") is not None and amt > float(r["max_amount"]): ok = False
+
+        if ok:
+            return r.get("category_id")
+    return None

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -1,0 +1,13 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    database_url: str = "sqlite:///./fintrack.db"
+    enable_notion: bool = False
+    notion_token: str | None = None
+    notion_database_id: str | None = None
+
+
+settings = Settings()

--- a/services/api/app/database.py
+++ b/services/api/app/database.py
@@ -1,0 +1,15 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .config import settings
+
+engine = create_engine(settings.database_url, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .classify import apply_rules
+from .config import settings
+from .database import engine, get_db
+from .models import Base, Rule, Transaction
+from .notion import NotionClient
+from .schemas import OCRWebhook, TransactionCreate, TransactionRead
+
+# Create tables on startup (for demo/testing purposes)
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="FinTrack API")
+
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+notion_client: Optional[NotionClient] = None
+if settings.enable_notion and settings.notion_token and settings.notion_database_id:
+    notion_client = NotionClient(settings.notion_token, settings.notion_database_id)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request, db: Session = Depends(get_db)):
+    transactions = db.execute(select(Transaction).order_by(Transaction.id.desc())).scalars().all()
+    return templates.TemplateResponse("index.html", {"request": request, "transactions": transactions})
+
+
+@app.post("/transactions", response_model=TransactionRead)
+def create_transaction(payload: TransactionCreate, db: Session = Depends(get_db)):
+    tx = Transaction(**payload.dict())
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+
+    if tx.category_id is None:
+        rules = db.execute(select(Rule).where(Rule.user_id == tx.user_id)).scalars().all()
+        rule_dicts = [r.__dict__ for r in rules]
+        cat = apply_rules(rule_dicts, {"merchant": tx.merchant, "note": tx.note, "amount": float(tx.amount)})
+        if cat:
+            tx.category_id = cat
+            db.add(tx)
+            db.commit()
+            db.refresh(tx)
+
+    if notion_client:
+        notion_client.create_transaction({"id": tx.id, "amount": float(tx.amount), "merchant": tx.merchant})
+
+    return tx
+
+
+@app.get("/transactions", response_model=list[TransactionRead])
+def list_transactions(db: Session = Depends(get_db), user_id: Optional[int] = None):
+    stmt = select(Transaction)
+    if user_id is not None:
+        stmt = stmt.where(Transaction.user_id == user_id)
+    items = db.execute(stmt).scalars().all()
+    return items
+
+
+@app.post("/webhooks/ocr", response_model=TransactionRead)
+def webhook_ocr(payload: OCRWebhook, db: Session = Depends(get_db)):
+    tx = Transaction(**payload.dict())
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+
+    if tx.category_id is None:
+        rules = db.execute(select(Rule).where(Rule.user_id == tx.user_id)).scalars().all()
+        rule_dicts = [r.__dict__ for r in rules]
+        cat = apply_rules(rule_dicts, {"merchant": tx.merchant, "note": tx.note, "amount": float(tx.amount)})
+        if cat:
+            tx.category_id = cat
+            db.add(tx)
+            db.commit()
+            db.refresh(tx)
+
+    if notion_client:
+        notion_client.create_transaction({"id": tx.id, "amount": float(tx.amount), "merchant": tx.merchant})
+
+    return tx

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime, date
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "user"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(160), unique=True, nullable=False, index=True)
+    password_hash: Mapped[str] = mapped_column(String(256), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class Account(Base):
+    __tablename__ = "account"
+    __table_args__ = (
+        CheckConstraint("opening_balance >= 0", name="ck_account_opening_balance_non_negative"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), index=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    type: Mapped[str] = mapped_column(String(20), nullable=False)
+    currency: Mapped[str] = mapped_column(String(8), default="MXN")
+    opening_balance: Mapped[Numeric] = mapped_column(Numeric(12, 2), nullable=False, default=0)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
+class Category(Base):
+    __tablename__ = "category"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), index=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    color: Mapped[str | None] = mapped_column(String(16), default="#888888")
+    icon_emoji: Mapped[str | None] = mapped_column(String(16))
+    parent_id: Mapped[int | None] = mapped_column(ForeignKey("category.id"), index=True)
+    is_system: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    parent: Mapped["Category" | None] = relationship("Category", remote_side=[id], backref="children")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
+class Rule(Base):
+    __tablename__ = "rule"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), index=True, nullable=False)
+    pattern: Mapped[str] = mapped_column(String(160), nullable=False)
+    field: Mapped[str] = mapped_column(String(16), default="merchant")
+    category_id: Mapped[int | None] = mapped_column(ForeignKey("category.id"))
+    scope_account_id: Mapped[int | None] = mapped_column(ForeignKey("account.id"))
+    min_amount: Mapped[str | None]
+    max_amount: Mapped[str | None]
+    priority: Mapped[int] = mapped_column(Integer, default=100)
+    active: Mapped[bool] = mapped_column(Boolean, default=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime)
+
+
+class Transaction(Base):
+    __tablename__ = "transaction"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), index=True, nullable=False)
+    account_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False)
+    category_id: Mapped[int | None] = mapped_column(ForeignKey("category.id"))
+    date: Mapped[date] = mapped_column(Date, nullable=False, default=date.today)
+    amount: Mapped[Numeric] = mapped_column(Numeric(12, 2), nullable=False)
+    merchant: Mapped[str | None] = mapped_column(String(160))
+    note: Mapped[str | None] = mapped_column(String(255))
+    source: Mapped[str] = mapped_column(String(16), default="manual")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class Attachment(Base):
+    __tablename__ = "attachment"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), index=True, nullable=False)
+    transaction_id: Mapped[int | None] = mapped_column(ForeignKey("transaction.id"))
+    filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    mime: Mapped[str | None] = mapped_column(String(64))
+    size: Mapped[int | None] = mapped_column(Integer)
+    sha256: Mapped[str | None] = mapped_column(String(64), index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/services/api/app/notion.py
+++ b/services/api/app/notion.py
@@ -1,0 +1,14 @@
+"""Minimal Notion client used behind a feature flag."""
+
+from typing import Any
+
+
+class NotionClient:
+    def __init__(self, token: str, database_id: str):
+        self.token = token
+        self.database_id = database_id
+
+    def create_transaction(self, tx: dict) -> Any:
+        """Send transaction to Notion (placeholder implementation)."""
+        # In real implementation we'd call Notion API here.
+        return {"sent": True, "transaction": tx.get("id")}

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -1,0 +1,34 @@
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class TransactionBase(BaseModel):
+    user_id: int
+    account_id: int
+    amount: float
+    merchant: Optional[str] = None
+    note: Optional[str] = None
+    category_id: Optional[int] = None
+    date: date = Field(default_factory=date.today)
+    source: str = "manual"
+
+
+class TransactionCreate(TransactionBase):
+    pass
+
+
+class TransactionRead(TransactionBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class OCRWebhook(TransactionBase):
+    """Payload sent by OCR service via webhook."""
+
+    source: str = "ocr"
+    note: Optional[str] = Field(default="(OCR)")

--- a/services/api/app/templates/index.html
+++ b/services/api/app/templates/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>FinTrack Dashboard</title>
+</head>
+<body>
+    <h1>Transactions</h1>
+    <ul>
+    {% for tx in transactions %}
+        <li>{{ tx.date }} - {{ tx.merchant or "N/A" }} - {{ tx.amount }}</li>
+    {% else %}
+        <li>No transactions</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI application under services/api/app with SQLAlchemy models and Pydantic schemas
- implement transaction and webhook routes plus health check and HTML dashboard
- include rule engine and optional Notion client

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac824fc578832db162b9fe8a0257aa