### PR TITLE
Add OCR webhook with HMAC verification

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     enable_notion: bool = False
     notion_token: str | None = None
     notion_database_id: str | None = None
+    webhook_secret: str = "changeme"
 
 
 settings = Settings()

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
+import json
 
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, Request, Header, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import select
@@ -12,9 +13,10 @@ from sqlalchemy.orm import Session
 from .classify import apply_rules
 from .config import settings
 from .database import engine, get_db
-from .models import Base, Rule, Transaction
+from .models import Base, Rule, Transaction, Attachment
 from .notion import NotionClient
-from .schemas import OCRWebhook, TransactionCreate, TransactionRead
+from .schemas import TransactionCreate, TransactionRead
+from .security import verify_hmac
 
 # Create tables on startup (for demo/testing purposes)
 Base.metadata.create_all(bind=engine)
@@ -71,24 +73,42 @@ def list_transactions(db: Session = Depends(get_db), user_id: Optional[int] = No
     return items
 
 
-@app.post("/webhooks/ocr", response_model=TransactionRead)
-def webhook_ocr(payload: OCRWebhook, db: Session = Depends(get_db)):
-    tx = Transaction(**payload.dict())
-    db.add(tx)
+@app.post("/webhooks/ocr")
+async def webhook_ocr(
+    request: Request,
+    x_signature: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+):
+    body = await request.body()
+    if not x_signature or not verify_hmac(body, x_signature, settings.webhook_secret):
+        raise HTTPException(status_code=400, detail="invalid signature")
+
+    data = json.loads(body.decode())
+    attachment_id = data.get("attachment_id")
+    text = data.get("text")
+    if attachment_id is None:
+        raise HTTPException(status_code=422, detail="attachment_id required")
+
+    att = db.get(Attachment, attachment_id)
+    if att is None:
+        raise HTTPException(status_code=404, detail="attachment not found")
+
+    att.ocr_text = text
+    db.add(att)
+
+    if att.transaction_id:
+        tx = db.get(Transaction, att.transaction_id)
+        if tx and tx.category_id is None:
+            rules = db.execute(select(Rule).where(Rule.user_id == tx.user_id)).scalars().all()
+            rule_dicts = [r.__dict__ for r in rules]
+            cat = apply_rules(
+                rule_dicts,
+                {"merchant": tx.merchant, "note": tx.note, "amount": float(tx.amount)},
+            )
+            if cat:
+                tx.category_id = cat
+                db.add(tx)
+
     db.commit()
-    db.refresh(tx)
 
-    if tx.category_id is None:
-        rules = db.execute(select(Rule).where(Rule.user_id == tx.user_id)).scalars().all()
-        rule_dicts = [r.__dict__ for r in rules]
-        cat = apply_rules(rule_dicts, {"merchant": tx.merchant, "note": tx.note, "amount": float(tx.amount)})
-        if cat:
-            tx.category_id = cat
-            db.add(tx)
-            db.commit()
-            db.refresh(tx)
-
-    if notion_client:
-        notion_client.create_transaction({"id": tx.id, "amount": float(tx.amount), "merchant": tx.merchant})
-
-    return tx
+    return {"status": "ok"}

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -101,4 +101,5 @@ class Attachment(Base):
     mime: Mapped[str | None] = mapped_column(String(64))
     size: Mapped[int | None] = mapped_column(Integer)
     sha256: Mapped[str | None] = mapped_column(String(64), index=True)
+    ocr_text: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/services/api/app/security.py
+++ b/services/api/app/security.py
@@ -1,0 +1,16 @@
+import hashlib
+import hmac
+
+
+def verify_hmac(body: bytes, signature: str, secret: str) -> bool:
+    """Verify HMAC-SHA256 signature for the given body.
+
+    Args:
+        body: Raw request body as bytes.
+        signature: Hex-encoded HMAC sent by client.
+        secret: Shared secret used to compute HMAC.
+    Returns:
+        True if signature is valid, False otherwise.
+    """
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(digest, signature)

--- a/tests/test_ocr_webhook.py
+++ b/tests/test_ocr_webhook.py
@@ -1,0 +1,72 @@
+import os
+import json
+import hmac
+import hashlib
+import pathlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+# set environment before importing app
+os.environ['DATABASE_URL'] = 'sqlite:///test_ocr.db'
+os.environ['WEBHOOK_SECRET'] = 'testsecret'
+
+from services.api.app.main import app  # noqa: E402
+from services.api.app.database import SessionLocal, engine  # noqa: E402
+from services.api.app.models import Base, User, Account, Category, Rule, Transaction, Attachment  # noqa: E402
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    db_path = pathlib.Path('test_ocr.db')
+    if db_path.exists():
+        db_path.unlink()
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _create_sample_data():
+    db = SessionLocal()
+    user = User(email='u@example.com', password_hash='x')
+    db.add(user)
+    db.commit(); db.refresh(user)
+    acc = Account(user_id=user.id, name='Cash', type='cash', currency='MXN', opening_balance=0)
+    db.add(acc)
+    cat = Category(user_id=user.id, name='Food', kind='expense')
+    db.add(cat)
+    db.commit(); db.refresh(acc); db.refresh(cat)
+    rule = Rule(user_id=user.id, pattern='Shop', field='merchant', category_id=cat.id)
+    db.add(rule); db.commit(); db.refresh(rule)
+    tx = Transaction(user_id=user.id, account_id=acc.id, amount=10, merchant='Shop', note='x')
+    db.add(tx); db.commit(); db.refresh(tx)
+    att = Attachment(user_id=user.id, transaction_id=tx.id, filename='a.jpg')
+    db.add(att); db.commit(); db.refresh(att)
+    db.close()
+    return att.id, tx.id, cat.id
+
+
+def test_webhook_valid_signature(client):
+    att_id, tx_id, cat_id = _create_sample_data()
+    body = json.dumps({'attachment_id': att_id, 'text': 'hello'}).encode()
+    sig = hmac.new(b'testsecret', body, hashlib.sha256).hexdigest()
+    res = client.post('/webhooks/ocr', data=body, headers={'X-Signature': sig})
+    assert res.status_code == 200
+    db = SessionLocal()
+    att = db.get(Attachment, att_id)
+    tx = db.get(Transaction, tx_id)
+    assert att.ocr_text == 'hello'
+    assert tx.category_id == cat_id
+    db.close()
+
+
+def test_webhook_invalid_signature(client):
+    att_id, tx_id, cat_id = _create_sample_data()
+    body = json.dumps({'attachment_id': att_id, 'text': 'hello'}).encode()
+    res = client.post('/webhooks/ocr', data=body, headers={'X-Signature': 'bad'})
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- add HMAC utility for validating webhook signatures
- extend Attachment model with OCR text field
- expose `/webhooks/ocr` endpoint that validates signature and stores OCR text, reapplying classification
- add tests covering valid and invalid webhook signatures

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68ac84405b94832db838b3ded59531f7