### PR TITLE
Render recent transactions with balance

### DIFF
--- a/services/api/app/static/style.css
+++ b/services/api/app/static/style.css
@@ -1,0 +1,4 @@
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 2rem; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ddd; padding: 8px; }
+th { background: #f3f3f3; text-align: left; }

--- a/services/api/app/templates/index.html
+++ b/services/api/app/templates/index.html
@@ -3,15 +3,26 @@
 <head>
     <meta charset="utf-8">
     <title>FinTrack Dashboard</title>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>Transactions</h1>
-    <ul>
-    {% for tx in transactions %}
-        <li>{{ tx.date }} - {{ tx.merchant or "N/A" }} - {{ tx.amount }}</li>
-    {% else %}
-        <li>No transactions</li>
-    {% endfor %}
-    </ul>
+    <h1>Recent Transactions</h1>
+    <p>Balance: {{ '%.2f' % balance }}</p>
+    <table>
+        <thead>
+            <tr><th>Date</th><th>Merchant</th><th>Amount</th></tr>
+        </thead>
+        <tbody>
+        {% for tx in transactions %}
+            <tr>
+                <td>{{ tx.date }}</td>
+                <td>{{ tx.merchant or 'N/A' }}</td>
+                <td>{{ '%.2f' % tx.amount }}</td>
+            </tr>
+        {% else %}
+            <tr><td colspan="3">No transactions</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Show last 10 transactions and account balance on root page
- Serve static stylesheet for basic table styling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a192514832da88f6673c3a521ba