### PR TITLE
Add API and bot integration tests with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/services/api/tests/test_classify.py
+++ b/services/api/tests/test_classify.py
@@ -1,0 +1,28 @@
+import pytest
+
+from services.api.app.classify import apply_rules
+
+
+def test_apply_rules_priority_and_active():
+    rules = [
+        {"pattern": "coffee", "category_id": 1, "priority": 50},
+        {"pattern": "coffee", "category_id": 2, "priority": 10, "active": False},
+    ]
+    tx = {"merchant": "Coffee Shop", "note": "", "amount": 5}
+    assert apply_rules(rules, tx) == 1
+
+
+def test_apply_rules_regex_amount_and_field():
+    rules = [
+        {
+            "pattern": "re:taxi$",
+            "field": "note",
+            "category_id": 3,
+            "min_amount": 10,
+            "max_amount": 30,
+        }
+    ]
+    tx_ok = {"merchant": "Uber", "note": "night taxi", "amount": 20}
+    assert apply_rules(rules, tx_ok) == 3
+    tx_low = {"merchant": "Uber", "note": "night taxi", "amount": 5}
+    assert apply_rules(rules, tx_low) is None

--- a/services/api/tests/test_endpoints.py
+++ b/services/api/tests/test_endpoints.py
@@ -1,0 +1,80 @@
+import os
+import pathlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Configure test database before importing the app
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_api.db")
+
+from services.api.app.main import app
+from services.api.app.database import SessionLocal, engine
+from services.api.app import models
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    models.Base.metadata.drop_all(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+    yield
+    models.Base.metadata.drop_all(bind=engine)
+    db_path = pathlib.Path("./test_api.db")
+    if db_path.exists():
+        db_path.unlink()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def seed_basic_data():
+    db = SessionLocal()
+    user = models.User(id=1, email="test@example.com", password_hash="x")
+    account = models.Account(id=1, user_id=1, name="Cash", type="cash", opening_balance=0)
+    category = models.Category(id=1, user_id=1, name="Food", kind="expense")
+    rule = models.Rule(id=1, user_id=1, pattern="Star", category_id=1)
+    db.add_all([user, account, category, rule])
+    db.commit()
+    db.close()
+
+
+def test_health(client):
+    res = client.get("/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
+def test_transactions_endpoint(client):
+    seed_basic_data()
+    payload = {
+        "user_id": 1,
+        "account_id": 1,
+        "amount": -5,
+        "merchant": "Starbucks",
+        "note": "latte",
+    }
+    res = client.post("/transactions", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["category_id"] == 1
+
+    res = client.get("/transactions")
+    items = res.json()
+    assert len(items) == 1
+    assert items[0]["merchant"] == "Starbucks"
+
+
+def test_webhook_ocr_endpoint(client):
+    seed_basic_data()
+    payload = {
+        "user_id": 1,
+        "account_id": 1,
+        "amount": -10,
+        "merchant": "Starbucks",
+    }
+    res = client.post("/webhooks/ocr", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["note"] == "(OCR)"
+    assert data["category_id"] == 1

--- a/services/bot/tests/test_integration.py
+++ b/services/bot/tests/test_integration.py
@@ -1,0 +1,88 @@
+import importlib
+import os
+import pathlib
+
+import pytest
+from httpx import AsyncClient
+
+# configure environment for tests before importing modules
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_bot.db")
+os.environ.setdefault("API_BASE_URL", "http://test")
+
+from services.api.app.main import app
+from services.api.app.database import SessionLocal, engine
+from services.api.app import models
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    models.Base.metadata.drop_all(bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+    yield
+    models.Base.metadata.drop_all(bind=engine)
+    db_path = pathlib.Path("./test_bot.db")
+    if db_path.exists():
+        db_path.unlink()
+
+
+def seed_basic_data():
+    db = SessionLocal()
+    user = models.User(id=1, email="user@example.com", password_hash="x")
+    account = models.Account(id=1, user_id=1, name="Cash", type="cash", opening_balance=0)
+    db.add_all([user, account])
+    db.commit()
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_post_transaction_integration(monkeypatch):
+    seed_basic_data()
+    import services.bot.main as bot_main
+    importlib.reload(bot_main)
+
+    async with AsyncClient(app=app, base_url="http://test") as test_client:
+        class MockClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return test_client
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        monkeypatch.setattr(bot_main.httpx, "AsyncClient", MockClient)
+        await bot_main.post_transaction(12.5, "Shop", note="", income=False)
+
+    db = SessionLocal()
+    tx = db.query(models.Transaction).first()
+    assert float(tx.amount) == -12.5
+    assert tx.merchant == "Shop"
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_post_transaction_income(monkeypatch):
+    seed_basic_data()
+    import services.bot.main as bot_main
+    importlib.reload(bot_main)
+
+    async with AsyncClient(app=app, base_url="http://test") as test_client:
+        class MockClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return test_client
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        monkeypatch.setattr(bot_main.httpx, "AsyncClient", MockClient)
+        await bot_main.post_transaction(20, "Salary", note="", income=True)
+
+    db = SessionLocal()
+    tx = db.query(models.Transaction).first()
+    assert float(tx.amount) == 20.0
+    assert tx.merchant == "Salary"
+    db.close()


### PR DESCRIPTION
## Summary
- add tests for classification rules and API endpoints
- add integration tests for bot transaction commands
- run pytest in new CI workflow

## Testing
- `pytest services/api/tests services/bot/tests` *(fails: command not found: pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8d9a1e64832dbcb322d226f57985