### PR TITLE
Add Discord bot HTTP call tests and docs

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,7 @@ REDIS_PORT=6379
 REDIS_PASSWORD=
 
 # Discord bot configuration
-DISCORD_BOT_TOKEN=
+DISCORD_BOT_TOKEN=your_bot_token_here
 DISCORD_GUILD_ID=
 
 # Notion configuration

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ docker-compose up --build
 ```
 
 ## Bot de Discord
+El bot usa [discord.py](https://discordpy.readthedocs.io/) y expone los comandos `/gasto`, `/ingreso` y `/foto`.
+
 1. Crea una aplicación en el [Portal de Desarrolladores de Discord](https://discord.com/developers/applications).
 2. En "Bot", habilita los scopes `bot` y `applications.commands` al generar el enlace de invitación.
 3. Intents requeridos: `Guilds` (por defecto) y `Message Content` si deseas procesar adjuntos.
 4. Invita el bot a tu servidor usando el enlace generado.
-5. Guarda el token en `.env` (`DISCORD_BOT_TOKEN`) y opcionalmente el ID de tu guild en `DISCORD_GUILD_ID`.
+5. Copia el token del bot y colócalo en `.env` como `DISCORD_BOT_TOKEN`. Opcionalmente define `DISCORD_GUILD_ID`.
 
 ## Túnel con Cloudflared
 1. Instala [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/).

--- a/services/bot/tests/test_http_calls.py
+++ b/services/bot/tests/test_http_calls.py
@@ -1,0 +1,62 @@
+import importlib
+import asyncio
+
+"""Tests for Discord bot HTTP interactions using mocked httpx."""
+
+
+def test_post_transaction_calls_api(monkeypatch):
+    monkeypatch.setenv("API_BASE_URL", "http://api.test")
+    import services.bot.main as bot_main
+    importlib.reload(bot_main)
+
+    captured = {}
+
+    class MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json=None, files=None):
+            captured["url"] = url
+            captured["json"] = json
+            captured["files"] = files
+
+    monkeypatch.setattr(bot_main.httpx, "AsyncClient", MockClient)
+    asyncio.run(bot_main.post_transaction(15.0, "Store", "note", income=False))
+
+    assert captured["url"] == "http://api.test/transactions"
+    assert captured["json"]["amount"] == -15.0
+    assert captured["json"]["merchant"] == "Store"
+def test_send_photo_calls_webhook(monkeypatch):
+    monkeypatch.setenv("N8N_WEBHOOK_URL", "http://webhook.test/ocr")
+    import services.bot.main as bot_main
+    importlib.reload(bot_main)
+
+    captured = {}
+
+    class MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json=None, files=None):
+            captured["url"] = url
+            captured["files"] = files
+
+    monkeypatch.setattr(bot_main.httpx, "AsyncClient", MockClient)
+
+    class DummyAttachment:
+        filename = "receipt.jpg"
+
+        async def read(self):
+            return b"fake-bytes"
+
+    asyncio.run(bot_main.send_photo(DummyAttachment()))
+
+    assert captured["url"] == "http://webhook.test/ocr"
+    assert "file" in captured["files"]
+    assert captured["files"]["file"][0] == "receipt.jpg"


### PR DESCRIPTION
## Summary
- document Discord bot setup and commands in README
- mock HTTP calls for bot features
- expose DISCORD_BOT_TOKEN in env template

## Testing
- `PYTHONPATH=. pytest` *(fails: No module named 'redis')*
- `pip install redis` *(fails: Tunnel connection failed: 403 Forbidden)*
- `PYTHONPATH=. pytest services/bot/tests/test_http_calls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac959363a8832dbf5a130fd756a2d4